### PR TITLE
Exposing Order interface

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,4 +1,4 @@
-interface Order {
+export interface Order {
   [key: string]: Order | null
 }
 


### PR DESCRIPTION
I added an `export` to expose publicly the Order interface